### PR TITLE
Enhance 3D point cloud

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,10 +9,23 @@ svg.call(
     viewport.attr('transform', zoomTransform);
   })
 );
-const simulation = d3.forceSimulation()
-  .force("link", d3.forceLink().id(d=>d.id).distance(120).strength(d=>d.strength))
-  .force("charge", d3.forceManyBody().strength(-80))
-  .force("center", d3.forceCenter(width/2,height/2))
+let render = ()=>{};
+
+const camera = { rotX: 0.3, rotY: 0.3, distance: 800 };
+document.addEventListener('keydown',ev=>{
+  const step=0.1;
+  if(ev.key==='ArrowUp') camera.rotX-=step;
+  if(ev.key==='ArrowDown') camera.rotX+=step;
+  if(ev.key==='ArrowLeft') camera.rotY-=step;
+  if(ev.key==='ArrowRight') camera.rotY+=step;
+  if(ev.key==='w') camera.distance=Math.max(100,camera.distance-20);
+  if(ev.key==='s') camera.distance+=20;
+  render();
+});
+
+const simulation = d3.forceSimulation().numDimensions(3)
+  .force("link", d3.forceLink().id(d=>d.id).distance(150).strength(d=>d.strength))
+  .force("charge", d3.forceManyBody().strength(-120))
   .force("collide", d3.forceCollide().radius(d=>{
     if(d.type==='star') return 18;
     if(d.type==='planet') return 12;
@@ -20,10 +33,15 @@ const simulation = d3.forceSimulation()
     return 8;
   }));
 Promise.all([
-  'varietals.json','wine_types.json','regions.json','avas.json',
-  'pizza_styles.json','toppings.json','bottles.json','links.json'
+  "varietals.json","wine_types.json","regions.json","avas.json",
+  "pizza_styles.json","toppings.json","bottles.json","links.json"
 ].map(d=>d3.json(d))).then(([varietals,types,regions,avas,pizzas,toppings,bottles,links])=>{
   const nodes=[...varietals,...types,...regions,...avas,...pizzas,...toppings,...bottles];
+  nodes.forEach(n=>{
+    n.x=(Math.random()-0.5)*width*2;
+    n.y=(Math.random()-0.5)*height*2;
+    n.z=(Math.random()-0.5)*400;
+  });
   simulation.nodes(nodes);
   simulation.force('link').links(links);
   const nodeElems=viewport.selectAll('text').data(nodes).enter().append('text')
@@ -34,11 +52,27 @@ Promise.all([
         return 12;
       });
   const linkElems=viewport.selectAll('line').data(links).enter().append('line').attr('class','link');
-  simulation.on('tick',()=>{
-    nodeElems.attr('x',d=>d.x).attr('y',d=>d.y);
-    linkElems.attr('x1',d=>d.source.x).attr('y1',d=>d.source.y)
-      .attr('x2',d=>d.target.x).attr('y2',d=>d.target.y);
-  });
+  simulation.on('tick',render);
+
+  function project(d){
+    const cosX=Math.cos(camera.rotX), sinX=Math.sin(camera.rotX);
+    const cosY=Math.cos(camera.rotY), sinY=Math.sin(camera.rotY);
+    let x=d.x, y=d.y, z=d.z;
+    let y1=cosX*y - sinX*z;
+    let z1=sinX*y + cosX*z;
+    let x1=cosY*x + sinY*z1;
+    z1=-sinY*x + cosY*z1;
+    const p=camera.distance/(camera.distance - z1);
+    return {x:x1*p, y:y1*p, scale:p};
+  }
+
+  function render(){
+    nodeElems.attr('transform',d=>{
+      const p=project(d); return `translate(${p.x},${p.y}) scale(${p.scale})`;
+    });
+    linkElems.attr('x1',d=>project(d.source).x).attr('y1',d=>project(d.source).y)
+      .attr('x2',d=>project(d.target).x).attr('y2',d=>project(d.target).y);
+  }
   let focus=null;
   nodeElems.on('click',(ev,d)=>{
     ev.stopPropagation();

--- a/index.html
+++ b/index.html
@@ -17,5 +17,6 @@ body{margin:0;background:#000;color:#fff;font-family:monospace;overflow:hidden}
   <g id="viewport"></g>
 </svg>
 <script src="https://d3js.org/d3.v7.min.js"></script>
+<script src="https://unpkg.com/d3-force-3d@3"></script>
 <script src="app.js"></script>
 </body></html>


### PR DESCRIPTION
## Summary
- allow forward/backward camera movement using **w** and **s** keys
- remove center forces and randomize initial node positions for a freer point cloud
- adjust charge and link distance so nodes spread out in 3D space

## Testing
- `node -e "new Function(require('fs').readFileSync('app.js','utf8')); console.log('syntax ok');"`

------
https://chatgpt.com/codex/tasks/task_e_6839f270efb88328a0ee9ee188cd270f